### PR TITLE
Add cffi-specific install instructions and docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,61 @@ For an introduction and further documentation, see `doc/main.txt`_.
 
 For installation information, see `INSTALL.txt`_.
 
+Why is there a cffi branch?
+---------------------------
+
+This is an experimental branch of lxml that uses ``cffi`` instead of
+C-extensions to compile lxml. This means it is compatible with, among others,
+the Pypy project.
+
+Is this ready for production?
+-----------------------------
+
+The lxml-cffi branch has passed tests X, Y, and Z and companies A, B, and C are
+using it in production. However it is still very much new software and your
+mileage may vary.
+
+Installation
+------------
+
+If you are installing with CPython, you can use ``pip`` to install lxml.
+
+    .. code-block:: bash
+
+    pip install lxml
+
+This will download the lxml source code onto your machine and compile the lxml
+c-code for your machine. 
+
+If you are installing with Pypy, no compile step is necessary. Just copy the
+lxml source directory to any place that is checked by Python when it begins
+running. Here is one example usage, that will copy lxml-cffi into a virtualenv:
+
+.. code-block:: bash
+
+    virtualenv venv
+    source venv/bin/activate
+
+    mkdir -p tmp
+    pushd tmp
+        if [ ! -d lxml ]; then 
+            # Download the lxml code
+            git clone https://github.com/amauryfa/lxml.git
+        fi
+        pushd lxml
+            # Checkout the correct branch
+            git checkout cffi
+        popd
+    popd
+
+    # copy lxml into place, no compiling.
+    if [ -d venv/site-packages ]; then
+        cp -rf tmp/lxml/src/lxml venv/site-packages
+    else
+        cp -rf tmp/lxml/src/lxml venv/lib/pythonX.Y/site-packages
+    fi
+
+
 
 Support the project
 -------------------


### PR DESCRIPTION
I ran into a really dumb problem when trying to install this - I kept trying to compile lxml using pypy and it kept failing, which led to a lot of frustration. I've added some docs to the page about the cffi project and installation in general to try and avoid having others fall into the same pitfall.

I left a section about production readiness half-empty because I am not sure what steps have been done to test the library and/or who's currently using this in production.
